### PR TITLE
Remove calls to comScore UX API

### DIFF
--- a/mParticle-ComScore.podspec
+++ b/mParticle-ComScore.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-ComScore/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 6.12.0'
-    s.ios.dependency 'ComScore', '5.1.10'
+    s.ios.dependency 'ComScore', '5.1.11'
     s.frameworks = 'SystemConfiguration'
 
     s.ios.pod_target_xcconfig = {

--- a/mParticle-ComScore/MPKitComScore.m
+++ b/mParticle-ComScore/MPKitComScore.m
@@ -146,20 +146,6 @@ NSString *const ecsPartnerId = @"partnerId";
     return self;
 }
 
-- (MPKitExecStatus *)beginSession {
-    [SCORAnalytics notifyUxActive];
-
-    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceComScore) returnCode:MPKitReturnCodeSuccess];
-    return execStatus;
-}
-
-- (MPKitExecStatus *)endSession {
-    [SCORAnalytics notifyUxInactive];
-
-    MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceComScore) returnCode:MPKitReturnCodeSuccess];
-    return execStatus;
-}
-
 - (MPKitExecStatus *)logEvent:(MPEvent *)event {
     MPKitExecStatus *execStatus;
 


### PR DESCRIPTION
comScore's notion of a user experience and the requirements for
measuring its length are different than mParticle sessions. Only
apps that have background streaming functionality should use these
APIs, and they should be invoked immediately as/after media starts
or stops. In those cases, apps can make direct APIs calls to the
comScore SDK.