### PR TITLE
Add publicHeadersPath to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,8 @@ let package = Package(
                 .byName(name: "mParticle-Apple-SDK"),
                 .byName(name: "ComScore"),
             ],
-            path: "mParticle-ComScore"
+            path: "mParticle-ComScore",
+            publicHeadersPath: "."
         )
     ]
 )


### PR DESCRIPTION
# Summary

This PR adds a `publicHeadersPath` entry, which allows SPM to find headers for the creation of a module that can be imported.
